### PR TITLE
chore: enable bodyclose, dogsled linters, from sylabs 2029

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - containedctx
     - contextcheck
     - decorder
+    - dogsled
     - dupl
     - gofumpt
     - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
   disable-all: true
   enable-all: false
   enable:
+    - bodyclose
     - containedctx
     - contextcheck
     - decorder

--- a/e2e/cache/cache.go
+++ b/e2e/cache/cache.go
@@ -527,6 +527,7 @@ func netHash(url string) (hash string, err error) {
 	if err != nil {
 		return "", fmt.Errorf("error making http request: %w", err)
 	}
+	defer res.Body.Close()
 
 	headerDate := res.Header.Get("Last-Modified")
 	h := sha256.New()

--- a/internal/pkg/client/net/pull.go
+++ b/internal/pkg/client/net/pull.go
@@ -128,6 +128,7 @@ func pull(ctx context.Context, imgCache *cache.Handle, directTo, pullFrom string
 	if err != nil {
 		sylog.Fatalf("Error making http request: %v\n", err)
 	}
+	defer res.Body.Close()
 
 	headerDate := res.Header.Get("Last-Modified")
 	sylog.Debugf("HTTP Last-Modified header is: %s", headerDate)

--- a/internal/pkg/remote/endpoint/service.go
+++ b/internal/pkg/remote/endpoint/service.go
@@ -158,7 +158,7 @@ func (config *Config) GetAllServices() (map[string][]Service, error) {
 	reader := cacheReader
 
 	if cacheReader == nil {
-		res, err := client.Do(req)
+		res, err := client.Do(req) //nolint:bodyclose
 		if err != nil {
 			return nil, fmt.Errorf("error making request to server: %s", err)
 		} else if res.StatusCode != http.StatusOK {

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2758,7 +2758,7 @@ func (c *container) getFuseFdFromRPC(fds []int) ([]int, error) {
 
 	bufSpace := (len(fds) + 1) * 4
 	buf := make([]byte, unix.CmsgSpace(bufSpace))
-	_, _, _, _, err := unix.Recvmsg(socketPair[0], nil, buf, 0)
+	_, _, _, _, err := unix.Recvmsg(socketPair[0], nil, buf, 0) //nolint:dogsled
 	if err != nil {
 		return nil, fmt.Errorf("while receiving file descriptors: %s", err)
 	}


### PR DESCRIPTION
This pulls in sylabs PR

    sylabs/singularity #2029

The original PR has no description. 
