### PR TITLE
lint: enable gosec + corresponding fixes, from sylabs 2066

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - goimports
     - gomodguard
     - goprintffuncname
+    - gosec
     - gosimple
     - govet
     - grouper
@@ -42,3 +43,8 @@ linters-settings:
 issues:
   max-per-linter: 0
   max-same-issues: 0
+  exclude-rules:
+    - linters:
+        - gosec
+      text: "^(G107|G204|G306):"
+

--- a/cmd/internal/cli/apptainer_test.go
+++ b/cmd/internal/cli/apptainer_test.go
@@ -28,6 +28,7 @@ func TestCreateConfDir(t *testing.T) {
 	rand.Seed(time.Now().UnixNano()) //nolint:staticcheck
 	bytes := make([]byte, 8)
 	for i := 0; i < 8; i++ {
+		// #nosec G404
 		bytes[i] = byte(65 + rand.Intn(25))
 	}
 	dir := "/tmp/" + string(bytes)

--- a/docs/remote.go
+++ b/docs/remote.go
@@ -11,6 +11,7 @@
 package docs
 
 // Global content for help and man pages
+// #nosec G101
 const (
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// remote command

--- a/e2e/internal/e2e/const.go
+++ b/e2e/internal/e2e/const.go
@@ -1,0 +1,16 @@
+// Copyright (c) Contributors to the Apptainer project, established as
+//   Apptainer a Series of LF Projects LLC.
+//   For website terms of use, trademark policy, privacy policy and other
+//   project policies see https://lfprojects.org/policies
+// Copyright (c) 2023, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package e2e
+
+import "time"
+
+const (
+	httpTimeout = 1800 * time.Second
+)

--- a/e2e/internal/e2e/docker.go
+++ b/e2e/internal/e2e/docker.go
@@ -150,6 +150,7 @@ func StartRegistry(t *testing.T, env TestEnv) string {
 			}
 			app.ServeHTTP(w, r)
 		}),
+		ReadHeaderTimeout: httpTimeout,
 	}
 
 	registryListener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/e2e/internal/e2e/docker_auth_server.go
+++ b/e2e/internal/e2e/docker_auth_server.go
@@ -98,7 +98,10 @@ func startAuthServer(ln net.Listener, crt, key string) error {
 	}
 
 	http.Handle("/auth", &dockerAuthHandler{srv: srv})
-	return http.Serve(ln, nil)
+	server := &http.Server{
+		ReadHeaderTimeout: httpTimeout,
+	}
+	return server.Serve(ln)
 }
 
 func (d *dockerAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/apptainer/oci_delete_linux.go
+++ b/internal/app/apptainer/oci_delete_linux.go
@@ -43,6 +43,7 @@ func OciDelete(ctx context.Context, containerID string) error {
 	hooks := engineConfig.OciConfig.Hooks
 	if hooks != nil {
 		for _, h := range hooks.Poststop {
+			// #nosec G601
 			if err := exec.Hook(ctx, &h, &engineConfig.State.State); err != nil {
 				sylog.Warningf("%s", err)
 			}

--- a/internal/pkg/build/sources/conveyorPacker_oci.go
+++ b/internal/pkg/build/sources/conveyorPacker_oci.go
@@ -378,6 +378,7 @@ func (cp *OCIConveyorPacker) extractArchive(src string, dst string) error {
 		}
 
 		// ZipSlip protection - don't escape from dst
+		// #nosec G305
 		target := filepath.Join(dst, header.Name)
 		if !strings.HasPrefix(target, filepath.Clean(dst)+string(os.PathSeparator)) {
 			return fmt.Errorf("%s: illegal extraction path", target)
@@ -401,6 +402,7 @@ func (cp *OCIConveyorPacker) extractArchive(src string, dst string) error {
 			defer f.Close()
 
 			// copy over contents
+			// #nosec G110
 			if _, err := io.Copy(f, tr); err != nil {
 				return err
 			}

--- a/internal/pkg/build/sources/conveyorPacker_zypper.go
+++ b/internal/pkg/build/sources/conveyorPacker_zypper.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	zypperConf         = "/etc/zypp/zypp.conf"
-	osreleaseFile      = "/etc/os-release"
+	zypperConf    = "/etc/zypp/zypp.conf"
+	osreleaseFile = "/etc/os-release"
+	// #nosec G101
 	ssccredentialsFile = "/etc/zypp/credentials.d/SCCcredentials"
 	gpgKeyid           = "gpg-pubkey-307e3d54-5aaa90a5 gpg-pubkey-39db7c82-5f68629b"
 )

--- a/internal/pkg/image/packer/gocryptfs.go
+++ b/internal/pkg/image/packer/gocryptfs.go
@@ -2,6 +2,7 @@ package packer
 
 import (
 	"bytes"
+	// #nosec G501
 	"crypto/md5"
 	"crypto/rand"
 	"encoding/hex"
@@ -92,6 +93,7 @@ func (g *Gocryptfs) init(tmpDir string) (cryptInfo *cryptInfo, err error) {
 
 	switch g.keyInfo.Format {
 	case cryptkey.PEM, cryptkey.ENV:
+		// #nosec G401
 		hash := md5.Sum(buf)
 		cryptInfo.pass = hex.EncodeToString(hash[:])
 	case cryptkey.Passphrase:

--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -201,6 +201,7 @@ func (h *keyserverHandler) login(u *url.URL, username, password string, insecure
 
 	if insecure {
 		client.Transport = &http.Transport{
+			//#nosec G402
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},

--- a/internal/pkg/remote/endpoint/keyserver.go
+++ b/internal/pkg/remote/endpoint/keyserver.go
@@ -217,7 +217,7 @@ func (c *keyserverTransport) RoundTrip(req *http.Request) (*http.Response, error
 func newClient(keyservers []*ServiceConfig, op KeyserverOp) *http.Client {
 	innerTransport := http.DefaultTransport.(*http.Transport).Clone()
 	innerTransport.DisableKeepAlives = true
-	innerTransport.TLSClientConfig = &tls.Config{}
+	innerTransport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
 	innerClient := &http.Client{
 		Timeout:   5 * time.Second,
 		Transport: innerTransport,

--- a/internal/pkg/remote/remote_test.go
+++ b/internal/pkg/remote/remote_test.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// #nosec G101
 const testToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM"
 
 // NOTE: VerifyToken() cannot be fully tested unless we have a dummy token for the token service to authenticate, so we basically only test a few error cases.

--- a/internal/pkg/runtime/engine/apptainer/container_linux.go
+++ b/internal/pkg/runtime/engine/apptainer/container_linux.go
@@ -2792,7 +2792,8 @@ func (c *container) getFuseFdFromRPC(fds []int) ([]int, error) {
 	newfds := make([]int, 0, 1)
 
 	for _, msg := range msgs {
-		pfds, err := unix.ParseUnixRights(&msg)
+		m := msg
+		pfds, err := unix.ParseUnixRights(&m)
 		if err != nil {
 			return nil, fmt.Errorf("while getting file descriptor: %s", err)
 		}

--- a/internal/pkg/runtime/engine/oci/process_linux.go
+++ b/internal/pkg/runtime/engine/oci/process_linux.go
@@ -230,7 +230,8 @@ func (e *EngineOperations) PreStartProcess(ctx context.Context, pid int, masterC
 	if hooks != nil {
 		for _, ht := range [][]specs.Hook{hooks.CreateRuntime, hooks.CreateContainer, hooks.StartContainer} {
 			for _, h := range ht {
-				if err := exec.Hook(ctx, &h, &e.EngineConfig.State.State); err != nil {
+				hks := h
+				if err := exec.Hook(ctx, &hks, &e.EngineConfig.State.State); err != nil {
 					return err
 				}
 			}
@@ -269,7 +270,8 @@ func (e *EngineOperations) PostStartProcess(ctx context.Context, pid int) error 
 	hooks := e.EngineConfig.OciConfig.Hooks
 	if hooks != nil {
 		for _, h := range hooks.Poststart {
-			if err := exec.Hook(ctx, &h, &e.EngineConfig.State.State); err != nil {
+			hks := h
+			if err := exec.Hook(ctx, &hks, &e.EngineConfig.State.State); err != nil {
 				sylog.Warningf("%s", err)
 			}
 		}

--- a/internal/pkg/util/auth/auth_test.go
+++ b/internal/pkg/util/auth/auth_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/apptainer/apptainer/internal/pkg/test"
 )
 
+// #nosec G101
 const (
 	testToken     = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.TCYt5XsITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUcX16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtjPAYuNzVBAh4vGHSrQyHUdBBPM"
 	testTokenPath = "test_data/test_token"

--- a/internal/pkg/util/fs/mount/system_linux.go
+++ b/internal/pkg/util/fs/mount/system_linux.go
@@ -82,9 +82,10 @@ func (b *System) MountAll() error {
 			b.Points.GetByTag(tag).Sort()
 		}
 		for _, point := range b.Points.GetByTag(tag) {
+			p := point
 			if b.Mount != nil {
-				if err := b.Mount(&point, b); err != nil {
-					return fmt.Errorf("mount %s->%s error: %s", point.Source, point.Destination, err)
+				if err := b.Mount(&p, b); err != nil {
+					return fmt.Errorf("mount %s->%s error: %s", p.Source, p.Destination, err)
 				}
 			}
 		}

--- a/pkg/build/types/definition.go
+++ b/pkg/build/types/definition.go
@@ -139,9 +139,9 @@ func NewDefinitionFromJSON(r io.Reader) (d Definition, err error) {
 
 func UpdateDefinitionRaw(defs *[]Definition) {
 	var buf []byte
-	for _, def := range *defs {
+	for i, def := range *defs {
 		var tmp bytes.Buffer
-		populateRaw(&def, &tmp)
+		populateRaw(&(*defs)[i], &tmp)
 		def.Raw = tmp.Bytes()
 		buf = append(buf, tmp.Bytes()...)
 	}

--- a/pkg/util/unix/socket_test.go
+++ b/pkg/util/unix/socket_test.go
@@ -30,6 +30,7 @@ var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 func randSeq(n int) string {
 	b := make([]rune, n)
 	for i := range b {
+		//#nosec G404
 		b[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(b)


### PR DESCRIPTION
This pulls in 
* sylabs 2066

Original PR description:

> Enable the `gosec` linter in golangci-lint, and perform fixes / add `#nosec` directives, as appropriate, in code.
> 
> Also adds three specific `gosec` rules to golangci-lint "exclude" list due to large number of false positives.

