### PR TITLE
linter fixes for golangci-lint 1.55.1, from sylabs2281

### DIFF
--- a/internal/pkg/remote/credential/login_handler.go
+++ b/internal/pkg/remote/credential/login_handler.go
@@ -172,6 +172,7 @@ func (h *keyserverHandler) login(u *url.URL, username, password string, insecure
 	}, nil
 }
 
+//nolint:revive
 func (h *keyserverHandler) logout(_ *url.URL, _ string) error {
 	return nil
 }


### PR DESCRIPTION
This pulls in sylabs PR

     * sylabs/singularity #2281
 
The original PR description was:
> Misc. linter fixes for golangci-lint v1.55.1