### PR TITLE
chore: address context-related FIXMEs, from sylabs 2373

### DIFF
--- a/internal/pkg/build/sources/conveyorPacker_arch.go
+++ b/internal/pkg/build/sources/conveyorPacker_arch.go
@@ -113,9 +113,7 @@ func (cp *ArchConveyorPacker) prepareFakerootEnv() (func(), error) {
 }
 
 // Get just stores the source
-//
-// FIXME: use context for cancellation.
-func (cp *ArchConveyorPacker) Get(_ context.Context, b *types.Bundle) (err error) {
+func (cp *ArchConveyorPacker) Get(ctx context.Context, b *types.Bundle) (err error) {
 	cp.b = b
 
 	err = cp.getBootstrapOptions()
@@ -153,7 +151,7 @@ func (cp *ArchConveyorPacker) Get(_ context.Context, b *types.Bundle) (err error
 	args := []string{"-C", pacConf, "-c", "-G", "-M", cp.b.RootfsPath, "haveged"}
 	args = append(args, instList...)
 
-	pacCmd := exec.Command(pacstrapPath, args...)
+	pacCmd := exec.CommandContext(ctx, pacstrapPath, args...)
 	pacCmd.Stdout = os.Stdout
 	pacCmd.Stderr = os.Stderr
 	sylog.Debugf("\n\tPacstrap Path: %s\n\tPac Conf: %s\n\tRootfs: %s\n\tInstall List: %s\n", pacstrapPath, pacConf, cp.b.RootfsPath, instList)
@@ -163,7 +161,7 @@ func (cp *ArchConveyorPacker) Get(_ context.Context, b *types.Bundle) (err error
 	}
 
 	// Pacman package signing setup
-	cmd := exec.Command("arch-chroot", cp.b.RootfsPath, "/bin/sh", "-c", "haveged -w 1024; pacman-key --init; pacman-key --populate archlinux")
+	cmd := exec.CommandContext(ctx, "arch-chroot", cp.b.RootfsPath, "/bin/sh", "-c", "haveged -w 1024; pacman-key --init; pacman-key --populate archlinux")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err = cmd.Run(); err != nil {
@@ -171,7 +169,7 @@ func (cp *ArchConveyorPacker) Get(_ context.Context, b *types.Bundle) (err error
 	}
 
 	// Clean up haveged
-	cmd = exec.Command("arch-chroot", cp.b.RootfsPath, "pacman", "-Rs", "--noconfirm", "haveged")
+	cmd = exec.CommandContext(ctx, "arch-chroot", cp.b.RootfsPath, "pacman", "-Rs", "--noconfirm", "haveged")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err = cmd.Run(); err != nil {

--- a/internal/pkg/build/sources/conveyorPacker_busybox.go
+++ b/internal/pkg/build/sources/conveyorPacker_busybox.go
@@ -34,9 +34,7 @@ type BusyBoxConveyorPacker struct {
 }
 
 // Get just stores the source
-//
-// FIXME: use context for cancellation.
-func (c *BusyBoxConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
+func (c *BusyBoxConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
 	c.b = b
 
 	// get mirrorURL, OSVerison, and Includes components to definition
@@ -60,7 +58,7 @@ func (c *BusyBoxConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
 		return fmt.Errorf("while inserting busybox: %v", err)
 	}
 
-	cmd := exec.Command(busyBoxPath, `--install`, filepath.Join(c.b.RootfsPath, "/bin"))
+	cmd := exec.CommandContext(ctx, busyBoxPath, `--install`, filepath.Join(c.b.RootfsPath, "/bin"))
 
 	sylog.Debugf("\n\tBusyBox Path: %s\n\tMirrorURL: %s\n", busyBoxPath, mirrorurl)
 

--- a/internal/pkg/build/sources/conveyorPacker_yum.go
+++ b/internal/pkg/build/sources/conveyorPacker_yum.go
@@ -48,9 +48,7 @@ type YumConveyorPacker struct {
 }
 
 // Get downloads container information from the specified source
-//
-// FIXME: use context for cancellation.
-func (c *YumConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
+func (c *YumConveyor) Get(ctx context.Context, b *types.Bundle) (err error) {
 	c.b = b
 
 	// check for dnf or yum on system
@@ -93,7 +91,7 @@ func (c *YumConveyor) Get(_ context.Context, b *types.Bundle) (err error) {
 
 	// Do the install
 	sylog.Debugf("\n\tInstall Command Path: %s\n\tDetected Arch: %s\n\tOSVersion: %s\n\tMirrorURL: %s\n\tUpdateURL: %s\n\tIncludes: %s\n\tSetopt: %s\n", installCommandPath, runtime.GOARCH, c.osversion, c.mirrorurl, c.updateurl, c.include, c.setopt)
-	cmd := exec.Command(installCommandPath, args...)
+	cmd := exec.CommandContext(ctx, installCommandPath, args...)
 	if sylog.GetLevel() >= int(sylog.VerboseLevel) {
 		cmd.Stdout = os.Stdout
 	}


### PR DESCRIPTION
This pulls in sylabs PR
 * sylabs/singularity #2373

The original PR description was:
> In the process of satisfying the linters in # 2026 a number of 'FIXME' items were added. The majority of these deal with contexts that are not being used.
> 
> internal/pkg/build/sources/conveyorPacker_arch.go
> 
>     * [x]  111:// FIXME: use context for cancellation.
> 
> 
> internal/pkg/build/sources/conveyorPacker_yum.go
> 
>     * [x]  48:// FIXME: use context for cancellation.
> 
> 
> internal/pkg/build/sources/conveyorPacker_zypper.go
> 
>     * [x]  53:// FIXME: use context for cancellation.
> 
> 
> internal/pkg/build/sources/conveyorPacker_busybox.go
> 
>     * [x]  33:// FIXME: use context for cancellation.
> 
> 
> internal/pkg/runtime/launcher/oci/oci_runc_linux.go
> 
>     * [x]  26:// FIXME: use context for cancellation, or remove.
> 
>     * [x]  181:// FIXME: use context for cancellation, or remove
> 
> 
> internal/pkg/client/ocisif/ocisif.go
> 
>     * [x]  257:// FIXME: Use context for cancellation.
> 
> 
> internal/pkg/client/oras/oras.go
> 
>     * [x]  32:// FIXME: use context for cancellation.
> 
>     * [x]  104:// FIXME: use context for cancellation.
> 
>     * [x]  149:// FIXME: use context for cancellation.
> 
> 
> pkg/ocibundle/native/bundle_linux.go
> 
>     * [x]  120:// FIXME: use context for cancellation, or remove.
> 
>     * [x]  228:// FIXME: use context for cancellation, or remove.

