### PR TITLE
Address further FIXMEs, from sylabs 2409

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -717,19 +717,14 @@ func (c configTests) configGlobal(t *testing.T) {
 			directiveValue: "yes",
 			exit:           1,
 		},
-		// FIXME
-		// The e2e tests currently run inside a PID namespace.
-		//   (see internal/init/init_linux.go)
-		// We can't instruct systemd to manage our cgroups as the PIDs in our test namespace
-		// won't match what systemd sees.
-		// {
-		// 	name:           "SystemdCgroupsYes",
-		// 	argv:           []string{"--apply-cgroups", "testdata/cgroups/pids_limit.toml", c.sandboxImage, "true"},
-		// 	profile:        e2e.RootProfile,
-		// 	directive:      "systemd cgroups",
-		// 	directiveValue: "yes",
-		// 	exit:           0,
-		// },
+		{
+			name:           "SystemdCgroupsYes",
+			argv:           []string{"--apply-cgroups", "testdata/cgroups/pids_limit.toml", c.sandboxImage, "true"},
+			profile:        e2e.RootProfile,
+			directive:      "systemd cgroups",
+			directiveValue: "yes",
+			exit:           0,
+		},
 		{
 			name:           "SystemdCgroupNo",
 			argv:           []string{"--apply-cgroups", "testdata/cgroups/pids_limit.toml", c.sandboxImage, "true"},

--- a/internal/pkg/build/apps/apps.go
+++ b/internal/pkg/build/apps/apps.go
@@ -457,7 +457,6 @@ func appData(b *types.Bundle, a *App) string {
 	return filepath.Join(b.RootfsPath, "/scif/data/", a.Name)
 }
 
-// FIXME: Replace with Go, or existing util function?
 func copyWithfLr(src, dst string) error {
 	cp, err := bin.FindBin("cp")
 	if err != nil {

--- a/internal/pkg/util/crypt/crypt_dev_test.go
+++ b/internal/pkg/util/crypt/crypt_dev_test.go
@@ -84,14 +84,12 @@ func TestEncrypt(t *testing.T) {
 			key:       []byte("dummyKey"),
 			shallPass: false,
 		},
-		/* FIXME: deactivate because it creates too much variability in test results with CI
 		{
 			name:      "empty file",
 			path:      emptyFile.Name(),
 			key:       []byte("dummyKey"),
 			shallPass: false,
 		},
-		*/
 		{
 			name:      "valid file",
 			path:      tempTargetFile.Name(),


### PR DESCRIPTION
This pulls in sylabs PR
* sylabs/singularity# 2409


The original PR description was:
> **e2e: enable configGlobal SystemdCgroupsYes**
> 
> This test was disabled as it wasn't possible to run it within a PID namespace. Our e2e tests have not used a PIDn amespace for some time now, so we can enable it again.
> 
> **chore: drop FIXME from copyWithflr**
> 
> There isn't an easy way to replace `cp -fLr` with go code and be 100% certain that it has the exact same behaviour across all possible source / dest we could encounter when building a SCIF container.
> 
> Drop the FIXME. We'll keep using `cp -fLr`.
> 
> **crypt: enable emptyFile test**
> 
> Not clear exactly why this was disabled / what 'too much variability in test results with CI' means.
> 
> Possibly due to an issue on older distros? It is passing for me.
> 
> ### This fixes or addresses the following GitHub issues:
> 
>     * Fixes [chore: address FIXMEs (mostly context related) # 2027](https://github.com/sylabs/singularity/issues/2027)